### PR TITLE
Meduza: fix inline background-color userstyle for links in articles

### DIFF
--- a/Meduza/Meduza-Dark.user.css
+++ b/Meduza/Meduza-Dark.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Meduza.io – Dark [Ath]
 @namespace      athari
-@version        1.0.1
+@version        1.0.2
 @description    Dark theme for Meduza.io (Медуза.io). Supports all types of articles.
 @author         Athari (https://github.com/Athari)
 @homepageURL    https://github.com/Athari/AthariUserCSS
@@ -107,6 +107,9 @@
   /* Material */
   .GeneralMaterial-module-root {
     background: #111;
+  }
+  .GeneralMaterial-module-article a {
+    background-color: transparent !important;
   }
   [class^='Meta-module_root__'] {
     color: #999;


### PR DESCRIPTION
Improved readability for articles by ensuring inline background styles on links do not conflict with the dark theme.

- Added a CSS rule to force transparent background color for links within .GeneralMaterial-module-article.

Example: https://meduza.io/feature/2026/04/20/ormuzskiy-proliv-to-otkryvayut-to-zakryvayut-to-otkryvayut-to-zakryvayut-to-iran-to-ssha-to-iran-to-ssha-chto-tam-voobsche-proishodit

Before:

<img width="942" height="577" alt="image" src="https://github.com/user-attachments/assets/6c10a784-cc2b-4bbd-9cd6-6020cfadb086" />

After:

<img width="954" height="512" alt="image" src="https://github.com/user-attachments/assets/50f69f7f-336b-4d96-a2cc-30b167d7a1ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved link styling within article content to display with transparent backgrounds, eliminating unwanted background color overlays and enhancing visual consistency across articles.

* **Chores**
  * Code formatting updates and file structure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->