### PR TITLE
Meduza: fix flash news blocks background color on main page

### DIFF
--- a/Meduza/Meduza-Dark.user.css
+++ b/Meduza/Meduza-Dark.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Meduza.io – Dark [Ath]
 @namespace      athari
-@version        1.0.1
+@version        1.0.2
 @description    Dark theme for Meduza.io (Медуза.io). Supports all types of articles.
 @author         Athari (https://github.com/Athari)
 @homepageURL    https://github.com/Athari/AthariUserCSS
@@ -42,7 +42,7 @@
     --textColor: #eee !important;
     --metaColor: #999 !important;
   }
-
+  .SimpleBlock-module-is1to1,
   .Modal-module-isAuth .Modal-module-container {
     background: #333;
   }


### PR DESCRIPTION
Updated the user stylesheet to ensure important flash news blocks maintain a dark background consistent with the rest of the theme.

- Set background color to #333 for .SimpleBlock-module-is1to1 to prevent white backgrounds on main page news.

Example: meduza.io

Before:

<img width="1494" height="766" alt="image" src="https://github.com/user-attachments/assets/81a1ce36-ce6b-440b-9175-bb6035dd0f39" />

After:

<img width="1437" height="833" alt="image" src="https://github.com/user-attachments/assets/9352abf0-1910-486c-9009-ef3a03cd706f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined dark mode styling to ensure consistent appearance across all interface components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->