### PR TITLE
Meduza: Override box-shadow for flash news hotfix

### DIFF
--- a/Meduza/Meduza-Dark.user.css
+++ b/Meduza/Meduza-Dark.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Meduza.io – Dark [Ath]
 @namespace      athari
-@version        1.0.3
+@version        1.0.4
 @description    Dark theme for Meduza.io (Медуза.io). Supports all types of articles.
 @author         Athari (https://github.com/Athari)
 @homepageURL    https://github.com/Athari/AthariUserCSS
@@ -32,6 +32,10 @@
     color: #eee;
     box-shadow: inset 0 0 0 1px #000;
   }
+  .SimpleBlock-module-is1to1 {
+    background: #333;
+    box-shadow: inset 0 0 0 1px #000, inset 0 0 0 4px #b78a54;
+  }
   .TopicBlockItem-module-footer,
   .RichBlock-module-meta {
     color: #999;
@@ -42,7 +46,6 @@
     --textColor: #eee !important;
     --metaColor: #999 !important;
   }
-  .SimpleBlock-module-is1to1,
   .Modal-module-isAuth .Modal-module-container {
     background: #333;
   }


### PR DESCRIPTION
`.SimpleBlock-module-root` has `box-shadow: inset 0 0 0 1px #000;` which prevents additional shadow of flash news from meduza to be shown.

Before:
<img width="1370" height="328" alt="image" src="https://github.com/user-attachments/assets/f05dbed0-de04-4b74-b145-5bc0e61dd7f7" />


After:
<img width="1353" height="312" alt="image" src="https://github.com/user-attachments/assets/122cac74-b4d9-4714-ae50-a873413d7400" />

P.S. no idea how did I make the screenshot with this border on previous commit and why did it work there (maybe related to placement of css rules in file? not sure)